### PR TITLE
pin to sqlalchemy v1.3, since v1.4 breaks airflow

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y libpq-dev build-essential
 RUN pip3 install psycopg2
 
 # Install airflow and gusty
+RUN pip3 install sqlalchemy==1.3.23
 RUN pip3 install apache-airflow==2.0.0
 RUN pip3 install gusty==0.5.0
 


### PR DESCRIPTION
I'm guessing airflow will patch a fix soon, so could also use a looser pin for airflow? (e.g. `pip3 install apache-airflow~=2.0.0`)